### PR TITLE
Fix isort_fixer query

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "rules_isort",
-    version = "0.0.1",
+    version = "0.0.2",
 )
 
 bazel_dep(name = "rules_python", version = "0.34.0")

--- a/python/isort/private/isort_fixer.py
+++ b/python/isort/private/isort_fixer.py
@@ -234,7 +234,7 @@ def main() -> None:
     srcs_query_template = r"""let scope = {scope} in filter("^//.*\.py$", kind("source file", deps($scope except attr(tags, "(^\[|, )(noformat|no-format|no_format|no-isort-format|no_isort_format)(, |\]$)", $scope), 1)))"""  # pylint: disable=line-too-long
 
     # Query for targets which do not specify `imports = ["."]`
-    srcs_scope = r"""kind(py_.*, set({scope}) except attr(imports, "[\.\w\d\-_]+", kind("py_*", set({scope})))""".format(  # pylint: disable=line-too-long
+    srcs_scope = r"""kind(py_.*, set({scope}) except attr(imports, "[\.\w\d\-_]+", kind("py_*", set({scope}))))""".format(  # pylint: disable=line-too-long
         scope=" ".join(args.scope)
     )
 
@@ -254,7 +254,7 @@ def main() -> None:
     # pylint: disable-next=consider-using-dict-items
     for target in imports:
         imports[target]["src_targets"] = query_targets(
-            srcs_query_template.replace("{scope}", f"set({target})"),
+            srcs_query_template.replace("{scope}", target),
             args.bazel,
             workspace_dir,
         )

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """"rules_isort version"""
 
-VERSION = "0.0.1"
+VERSION = "0.0.2"


### PR DESCRIPTION
This fixes the following error
```
ERROR: Error while parsing 'let scope = kind(py_.*, set(//...:all) except attr(imports, "[\.\w\d\-_]+", kind("py_*", set(//...:all))) in filter("^//.*\.py$", kind("source file", deps($scope except attr(tags, "(^\[|, )(noformat|no-format|no_format|no-isort-format|no_isort_format)(, |\]$)", $scope), 1)))': syntax error at 'in filter ('
```